### PR TITLE
chore: clean up color mode button

### DIFF
--- a/src/components/ThemeToggleButton.js
+++ b/src/components/ThemeToggleButton.js
@@ -1,4 +1,10 @@
-import { LightMode, DarkMode, useColorMode, Button } from '@chakra-ui/core';
+import {
+  LightMode,
+  DarkMode,
+  useColorMode,
+  IconButton,
+  useColorModeValue,
+} from '@chakra-ui/core';
 
 import { FiSun, FiMoon } from 'react-icons/fi';
 
@@ -6,31 +12,16 @@ import { useThemePersistence } from '@hooks/useThemePersistance';
 
 export default function ThemeTogglebutton() {
   const { colorMode, toggleColorMode } = useColorMode();
+  const ToggleIcon = useColorModeValue(FiSun, FiMoon);
+
   useThemePersistence(colorMode);
 
-  if (colorMode === 'light') {
-    return (
-      <LightMode>
-        <Button
-          role="button"
-          aria-label="Toggle Theme"
-          onClick={toggleColorMode}
-        >
-          <FiSun />
-        </Button>
-      </LightMode>
-    );
-  } else if (colorMode === 'dark') {
-    return (
-      <DarkMode>
-        <Button
-          role="button"
-          aria-label="Toggle Theme"
-          onClick={toggleColorMode}
-        >
-          <FiMoon />
-        </Button>
-      </DarkMode>
-    );
-  }
+  return (
+    <IconButton
+      icon={<ToggleIcon />}
+      variant="ghost"
+      aria-label="Toggle Theme"
+      onClick={toggleColorMode}
+    />
+  );
 }


### PR DESCRIPTION
This PR cleans up the `ThemeToggleButton` component a bit. 

- used `useColorMode` value to switch between the two icons 
- converted to `IconButton` which is made specifically for this purpose
- set the `variant` to `ghost`, which has only a slight background on hover:

![image](https://user-images.githubusercontent.com/1954752/89952266-e942d680-dbfa-11ea-8187-20f596250e65.png)
![image](https://user-images.githubusercontent.com/1954752/89952246-e0ea9b80-dbfa-11ea-80e9-e7a75d8d96cf.png)
![image](https://user-images.githubusercontent.com/1954752/89952281-f233a800-dbfa-11ea-8e93-c49fb045e8ea.png)
![image](https://user-images.githubusercontent.com/1954752/89952292-f6f85c00-dbfa-11ea-83d9-488a8c8d14f5.png)
