### PR TITLE
feat: Support nested paths

### DIFF
--- a/packages/mdnext/pages/blog/[...slug].js
+++ b/packages/mdnext/pages/blog/[...slug].js
@@ -1,6 +1,7 @@
+import { promises as fs } from 'fs';
+import path from 'path';
 import renderToString from 'next-mdx-remote/render-to-string';
 import hydrate from 'next-mdx-remote/hydrate';
-import fs from 'fs';
 import matter from 'gray-matter';
 import glob from 'fast-glob';
 
@@ -23,19 +24,19 @@ export default function BlogPost({ mdxSource, frontMatter }) {
 }
 
 // This glob is what will be used to generate static routes
-const contentGlob = 'src/blogs/*.mdx';
+const contentPath = 'src/blogs';
+const contentGlob = `${contentPath}/**/*.mdx`;
 
 export async function getStaticPaths() {
   const files = glob.sync(contentGlob);
 
   const paths = files.map((file) => {
-    const split = file.split('/');
-    const filename = split[split.length - 1];
-    const slug = filename.replace('.mdx', '');
+    const filename = file.replace(`${contentPath}/`, '');
+    const slug = filename.replace(new RegExp(path.extname(file) + '$'), '');
 
     return {
       params: {
-        slug,
+        slug: [...slug.split('/')],
       },
     };
   });
@@ -49,18 +50,15 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params: { slug } }) {
   const files = glob.sync(contentGlob);
 
-  const fullPath = files.filter((item) => {
-    const split = item.split('/');
-    const filename = split[split.length - 1];
-    return filename.replace('.mdx', '') === slug;
-  })[0];
-
-  const mdxSource = fs.readFileSync(fullPath);
-  const { content, data } = matter(mdxSource);
+  const pathRegex = new RegExp(`^${contentPath}/${path.join(...slug)}.mdx$`);
+  const fullPath = files.find((file) => pathRegex.test(file));
 
   if (!fullPath) {
     console.warn('No MDX file found for slug');
   }
+
+  const mdxSource = await fs.readFile(fullPath);
+  const { content, data } = matter(mdxSource);
 
   const mdx = await renderToString(content, { components, scope: data });
 

--- a/packages/mdnext/pages/blog/[...slug].js
+++ b/packages/mdnext/pages/blog/[...slug].js
@@ -36,7 +36,7 @@ export async function getStaticPaths() {
 
     return {
       params: {
-        slug: [...slug.split('/')],
+        slug: slug.split('/'),
       },
     };
   });

--- a/packages/mdnext/src/blogs/example.mdx
+++ b/packages/mdnext/src/blogs/example.mdx
@@ -23,4 +23,4 @@ function App() {
 
 ## Instructions
 
-Edit `/src/mdx/example.mdx` ✅
+Edit `/src/blogs/example.mdx` ✅

--- a/packages/mdnext/src/blogs/example2.mdx
+++ b/packages/mdnext/src/blogs/example2.mdx
@@ -23,4 +23,4 @@ function App() {
 
 ## Instructions
 
-Edit `/src/mdx/example.mdx` ✅
+Edit `/src/blogs/example.mdx` ✅

--- a/packages/mdnext/src/blogs/example3.mdx
+++ b/packages/mdnext/src/blogs/example3.mdx
@@ -23,4 +23,4 @@ function App() {
 
 ## Instructions
 
-Edit `/src/mdx/example.mdx` ✅
+Edit `/src/blogs/example.mdx` ✅

--- a/packages/mdnext/src/blogs/nested/example.mdx
+++ b/packages/mdnext/src/blogs/nested/example.mdx
@@ -1,0 +1,12 @@
+---
+title: Nested Blog Posts
+tags: ['react', 'nextjs']
+author: Domitrius Clark
+description: A nested example
+---
+
+Nesting at it's finest
+
+## Instructions
+
+Edit `/src/blogs/nested/example.mdx` ✅


### PR DESCRIPTION
## Description

- changes dynamic routing to use [Next.js catch-all routes](https://nextjs.org/docs/routing/dynamic-routes#catch-all-routes) for nested files
  - NOTE: enables alternative structures such as `/blog/YYYY/MM/name-of-post`
- enhance `path` module usage
- changes `src/mdx/...` paths under the "Instructions" heading to `src/blogs/...`