### PR TITLE
Add a getMdxContent util function and use this for blog pages

### DIFF
--- a/templates/mdnext-blog/jsconfig.json
+++ b/templates/mdnext-blog/jsconfig.json
@@ -5,7 +5,8 @@
       "@theme": ["src/theme"],
       "@components/*": ["src/components/*"],
       "@utils/*": ["src/utils/*"],
-      "@hooks/*": ["src/hooks/*"]
+      "@hooks/*": ["src/hooks/*"],
+      "@config/*": ["src/config/*"]
     }
   }
 }

--- a/templates/mdnext-blog/pages/blog/[...slug].js
+++ b/templates/mdnext-blog/pages/blog/[...slug].js
@@ -1,14 +1,9 @@
-import { promises as fs } from 'fs';
-import path from 'path';
-import renderToString from 'next-mdx-remote/render-to-string';
 import hydrate from 'next-mdx-remote/hydrate';
-import matter from 'gray-matter';
-import glob from 'fast-glob';
 
-import Code from '@components/Code';
+import { BLOG_CONTENT_PATH } from '@config/constants';
+import { getMdxContent } from '@utils/get-mdx-content';
+import components from '@components/MDXComponents';
 import { Layout } from '@components/Layout';
-
-const components = { code: Code };
 
 export default function BlogPost({ mdxSource, frontMatter }) {
   const content = hydrate(mdxSource, { components });
@@ -23,28 +18,13 @@ export default function BlogPost({ mdxSource, frontMatter }) {
   );
 }
 
-// This glob is what will be used to generate static routes
-const contentPath = 'src/blogs';
-export const contentGlob = `${contentPath}/**/*.mdx`;
-export const getBlogFileSlug = (blogFilePath) => {
-  const filename = blogFilePath.replace(`${contentPath}/`, '');
-  const slug = filename.replace(
-    new RegExp(path.extname(blogFilePath) + '$'),
-    '',
-  );
-  return slug;
-};
-
 export async function getStaticPaths() {
-  const files = glob.sync(contentGlob);
-
-  const paths = files.map((file) => {
-    return {
-      params: {
-        slug: getBlogFileSlug(file).split('/'),
-      },
-    };
-  });
+  const posts = await getMdxContent(BLOG_CONTENT_PATH);
+  const paths = posts.map(({ slug }) => ({
+    params: {
+      slug: slug.split('/'),
+    },
+  }));
 
   return {
     paths,
@@ -53,24 +33,18 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params: { slug } }) {
-  const files = glob.sync(contentGlob);
+  const posts = await getMdxContent(BLOG_CONTENT_PATH);
+  const postSlug = slug.join('/');
+  const [post] = posts.filter((post) => post.slug === postSlug);
 
-  const pathRegex = new RegExp(`^${contentPath}/${path.join(...slug)}.mdx$`);
-  const fullPath = files.find((file) => pathRegex.test(file));
-
-  if (!fullPath) {
-    console.warn('No MDX file found for slug');
+  if (!post) {
+    console.warn(`No content found for slug ${postSlug}`);
   }
-
-  const mdxSource = await fs.readFile(fullPath);
-  const { content, data } = matter(mdxSource);
-
-  const mdx = await renderToString(content, { components, scope: data });
 
   return {
     props: {
-      mdxSource: mdx,
-      frontMatter: data,
+      mdxSource: post.mdx,
+      frontMatter: post.data,
     },
   };
 }

--- a/templates/mdnext-blog/pages/blog/index.js
+++ b/templates/mdnext-blog/pages/blog/index.js
@@ -1,13 +1,10 @@
-import { Box, Flex, Stack } from '@chakra-ui/core';
+import { Box, Stack } from '@chakra-ui/core';
 
-import glob from 'fast-glob';
-import fs from 'fs';
-import matter from 'gray-matter';
-
+import { BLOG_CONTENT_PATH } from '@config/constants';
+import { getMdxContent } from '@utils/get-mdx-content';
 import ContentBox from '@components/ContentBox';
 import Search from '@components/Search';
 import { Layout } from '@components/Layout';
-import { contentGlob, getBlogFileSlug } from './[...slug]';
 
 export default function BlogPage({ allMdx }) {
   const [filteredBlogs, setFilteredBlogs] = React.useState(allMdx);
@@ -33,20 +30,12 @@ export default function BlogPage({ allMdx }) {
   );
 }
 
-export function getStaticProps() {
-  const files = glob.sync(contentGlob);
-
-  const allMdx = files.map((file) => {
-    const slug = getBlogFileSlug(file);
-
-    const mdxSource = fs.readFileSync(file);
-    const { data } = matter(mdxSource);
-
-    return {
-      slug,
-      ...data,
-    };
-  });
+export async function getStaticProps() {
+  const posts = await getMdxContent(BLOG_CONTENT_PATH);
+  const allMdx = posts.map((post) => ({
+    slug: post.slug,
+    ...post.data,
+  }));
 
   return {
     props: {

--- a/templates/mdnext-blog/src/components/MDXComponents.js
+++ b/templates/mdnext-blog/src/components/MDXComponents.js
@@ -1,0 +1,3 @@
+import Code from '@components/Code';
+
+export default { code: Code };

--- a/templates/mdnext-blog/src/components/Search.js
+++ b/templates/mdnext-blog/src/components/Search.js
@@ -5,8 +5,6 @@ import { Flex, Stack, Input } from '@chakra-ui/core';
 
 import TagList from './TagList';
 
-const TAG_LIST = ['react', 'nextjs', 'chakra ui'];
-
 const fuseOptions = {
   threshold: 0.35,
   location: 0,
@@ -22,6 +20,7 @@ export default function Search({ blogs, handleFilter }) {
   const [searchValue, setSearchValue] = useState('');
   const [searchTags, setSearchTags] = useState([]);
   const fuse = new Fuse(blogs, fuseOptions);
+  const tags = [...new Set(blogs.flatMap(({ tags }) => tags))];
 
   React.useEffect(() => {
     if (searchValue === '' && searchTags.length === 0) {
@@ -65,7 +64,7 @@ export default function Search({ blogs, handleFilter }) {
       spacing={[6, 8, 10]}
     >
       <Flex justify="space-around">
-        <TagList tags={TAG_LIST} value={searchTags} onChange={setSearchTags} />
+        <TagList tags={tags} value={searchTags} onChange={setSearchTags} />
       </Flex>
       <Input value={searchValue} onChange={onChange} />
     </Stack>

--- a/templates/mdnext-blog/src/config/constants.js
+++ b/templates/mdnext-blog/src/config/constants.js
@@ -1,0 +1,1 @@
+export const BLOG_CONTENT_PATH = './src/blogs';

--- a/templates/mdnext-blog/src/utils/get-mdx-content.js
+++ b/templates/mdnext-blog/src/utils/get-mdx-content.js
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import renderToString from 'next-mdx-remote/render-to-string';
+import matter from 'gray-matter';
+import glob from 'fast-glob';
+
+import components from '@components/MDXComponents';
+
+export async function getMdxContent(source) {
+  const contentGlob = `${source}/**/*.mdx`;
+  const files = glob.sync(contentGlob);
+
+  if (!files.length) return [];
+
+  const content = await Promise.all(
+    files.map(async (filepath) => {
+      const slug = filepath
+        .replace(source, '')
+        .replace(/^\/+/, '')
+        .replace(new RegExp(path.extname(filepath) + '$'), '');
+
+      const mdxSource = await fs.readFile(filepath);
+      const { content, data } = matter(mdxSource);
+      const mdx = await renderToString(content, { components, scope: data });
+
+      return {
+        filepath,
+        slug,
+        content,
+        data,
+        mdx,
+      };
+    }),
+  );
+  return content;
+}


### PR DESCRIPTION
This PR 

1. Adds a `getMdxContent` util function that reads all `.mdx` file for the provided `source` path. This does the heavy lifting for `getStaticPaths` and `getStaticProps` for blog pages (if this works, we could extract this into a `@mdnext/utils` package and re-use it for other templates).
2. Moves `contentPath` to a `constants.js` file so that it can be imported wherever we need it (I found this approach in nextjs official repo: https://github.com/vercel/next-site/blob/master/lib/constants.js).
3. Adds a `src/components/MDXComponents.js` file to make it easy to group all components available for MDX in one place.
4. Implements dynamic tags for search.

Let me know what you think. 😁 

