### PR TITLE
Update email to report COC violations

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [email][email]. All
+reported by contacting the project team at domitrius@mdnext.dev. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -72,4 +72,3 @@ available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/
-[email]: coc@domitrius.dev


### PR DESCRIPTION
Apparently the link format doesn't work without a fully qualified link (so it'd have to be a `mailto:` link), so I just stuck it in the spot.