### PR TITLE
[Overlays] Twitch Env Variables and Chat Key

### DIFF
--- a/templates/mdnext-overlays/next.config.js
+++ b/templates/mdnext-overlays/next.config.js
@@ -7,7 +7,7 @@ module.exports = {
     CALLBACK_URL: process.env.CALLBACK_URL,
     PUBNUB_PUBLISH_KEY: process.env.PUBNUB_PUBLISH_KEY,
     PUBNUB_SUBSCRIBE_KEY: process.env.PUBNUB_SUBSCRIBE_KEY,
-    PUNUB_SECRET_KEY: process.env.PUBNUB_SUBSCRIBE_KEY,
+    PUBNUB_SECRET_KEY: process.env.PUBNUB_SECRET_KEY,
     AUTH_TOKEN: process.env.TWITCH_AUTH_TOKEN,
   },
 };

--- a/templates/mdnext-overlays/pages/scenes/multi-discussion.js
+++ b/templates/mdnext-overlays/pages/scenes/multi-discussion.js
@@ -18,7 +18,7 @@ const ALERT_TIMER = 4000;
 
 export default function MultiDiscussionScene({ frontMatter, streamDetails }) {
   const { connectListener, messages } = useChatListener({
-    channel: 'domitriusClark ',
+    channel: process.env.CHANNEL,
     commands: CHAT_COMMANDS,
   });
 

--- a/templates/mdnext-overlays/src/components/TwitchChatBox.js
+++ b/templates/mdnext-overlays/src/components/TwitchChatBox.js
@@ -4,8 +4,8 @@ import { Flex, Text } from '@chakra-ui/core';
 export default function TwitchChatBox(props) {
   return (
     <Flex {...props}>
-      {props.messages.map((message) => (
-        <Flex padding={2}>
+      {props.messages.map((message, index) => (
+        <Flex key={index} padding={2}>
           <Text color="tomato" mr={2}>
             {message.user}
           </Text>

--- a/templates/mdnext-overlays/src/hooks/useChatListener.js
+++ b/templates/mdnext-overlays/src/hooks/useChatListener.js
@@ -21,7 +21,7 @@ export default function useChatListener({ channel, commands = {} }) {
     },
     channels: [channel],
     identity: {
-      username: 'domitriusclark',
+      username: process.env.CHANNEL,
       password: process.env.AUTH_TOKEN,
     },
   });

--- a/templates/mdnext-overlays/src/hooks/useChatListener.js
+++ b/templates/mdnext-overlays/src/hooks/useChatListener.js
@@ -21,7 +21,7 @@ export default function useChatListener({ channel, commands = {} }) {
     },
     channels: [channel],
     identity: {
-      username: process.env.CHANNEL,
+      username: channel,
       password: process.env.AUTH_TOKEN,
     },
   });


### PR DESCRIPTION
Fixes several issues with environment variables between a few typos and using the defined values throughout in spots where it makes sense to pull dynamically.

Also fixed a warning where the map function within the Twitch chat box would complain about not having a `key` prop. `index` isn't always ideal, but I couldn't find any sort of "id" associated with each message, and we're not doing any kind of rearranging within the chatbox for it to have a huge impact on rendering.