### PR TITLE
Remove rogue semicolon

### DIFF
--- a/templates/mdnext-tailwind/pages/_app.js
+++ b/templates/mdnext-tailwind/pages/_app.js
@@ -20,7 +20,7 @@ export default function App({ Component, pageProps }) {
           site: 'https://twitter.com/domitriusclark',
         }}
       />
-      <Component {...pageProps} />;
+      <Component {...pageProps} />
     </>
   );
 }


### PR DESCRIPTION
This semicolon gets rendered in the browser if it's left here. Likely just a typo!